### PR TITLE
Removed the .NET 4.5 dependency. Using WMF5 Expand-Archive instead , …

### DIFF
--- a/DSCResources/cRavenDB/cRavenDB.psd1
+++ b/DSCResources/cRavenDB/cRavenDB.psd1
@@ -10,7 +10,7 @@
 
 RootModule = 'cRavenDB.psm1'
 
-ModuleVersion = '0.3'
+ModuleVersion = '0.4'
 
 GUID = '616876a3-25e8-4010-a386-12fbc7a8cde5'
 
@@ -26,7 +26,7 @@ PowerShellVersion = '5.0'
 
 FunctionsToExport = '*'
 
-RequiredAssemblies = @('System.IO.Compression.FileSystem')
+RequiredAssemblies = @()
 
 DscResourcesToExport = @('cRavenDB')
 


### PR DESCRIPTION
Removed .NET 4.5 dependency (and System.Io.Compression assemblies). Using Expand-Archive - Unzipping only tools/\* files into destination . Cleaning up temp files after completion. 
